### PR TITLE
Deprecate Bit-Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# JavaScript Bit Array Library
+## Bit-Array is deprecated. 
 
-## Bit-Array is deprecated. Please use <a href="https://github.com/infusion/BitSet.js" style="color: yellow;">BitSet.js</a>
+Please use <a href="https://github.com/infusion/BitSet.js" style="color: yellow;">BitSet.js</a>
+
+## JavaScript Bit Array Library
 
 This library contains a JavaScript implementation of bit arrays. The library supports:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## JavaScript Bit Array Library
+# JavaScript Bit Array Library
+
+## Bit-Array is deprecated. Please use <a href="https://github.com/infusion/BitSet.js" style="color: yellow;">BitSet.js</a>
 
 This library contains a JavaScript implementation of bit arrays. The library supports:
 


### PR DESCRIPTION
Hi Bram,

I hope the deprecation note is okay, unfortunately CSS is removed by github to highlight that info a little more. But thanks for allowing to deprecate bit-array in favor of bitset.js!

Robert